### PR TITLE
Update sumOfHighInterest Instructions

### DIFF
--- a/array-methods.js
+++ b/array-methods.js
@@ -86,15 +86,16 @@ var sumOfInterests = null;
 var stateSums = null;
 
 /*
-  from each of the following states:
+  for all states not in the following states:
     Wisconsin
     Illinois
     Wyoming
     Ohio
     Georgia
     Delaware
-  take each `amount` and add 18.9% interest to it
-  only sum values greater than 50,000 and save it to `sumOfInterests`
+  sum the amount for each state (stateSum)
+  take each `stateSum` and add 18.9% interest to it
+  sum only `stateSum` who's interest only values is greater than 50,000 and save it to `sumOfHighInterests`
 
   note: During your summation (
     if at any point durig your calculation where the number looks like `2486552.9779399997`

--- a/array-methods.js
+++ b/array-methods.js
@@ -86,7 +86,7 @@ var sumOfInterests = null;
 var stateSums = null;
 
 /*
-  for all states not in the following states:
+  for all states *NOT* in the following states:
     Wisconsin
     Illinois
     Wyoming

--- a/array-methods.js
+++ b/array-methods.js
@@ -94,8 +94,8 @@ var stateSums = null;
     Georgia
     Delaware
   sum the amount for each state (stateSum)
-  take each `stateSum` and add 18.9% interest to it
-  sum only `stateSum` interest values that are greater than 50,000 and save it to `sumOfHighInterests`
+  take each `stateSum` and calculate 18.9% interest for that state
+  sum the interest values that are greater than 50,000 and save it to `sumOfHighInterests`
 
   note: During your summation (
     if at any point durig your calculation where the number looks like `2486552.9779399997`

--- a/array-methods.js
+++ b/array-methods.js
@@ -95,7 +95,7 @@ var stateSums = null;
     Delaware
   sum the amount for each state (stateSum)
   take each `stateSum` and add 18.9% interest to it
-  sum only `stateSum` who's interest only values is greater than 50,000 and save it to `sumOfHighInterests`
+  sum only `stateSum` interest values that are greater than 50,000 and save it to `sumOfHighInterests`
 
   note: During your summation (
     if at any point durig your calculation where the number looks like `2486552.9779399997`


### PR DESCRIPTION
The instructions for sumOfHighInterest is not clear at all and actually misleads users from getting the right answer.