### PR TITLE
Remove decimal rounding

### DIFF
--- a/array-methods.js
+++ b/array-methods.js
@@ -7,50 +7,6 @@ var dataset = require('./dataset.json');
 */
 var hundredThousandairs = null;
 
-/*
-  DO NOT MUTATE DATA.
-
-  create a new dataset where each bank object is a new object.
-  `amount` and `state` values will be transferred to the new object.
-  This new object is different, you will add one new key of `rounded`
-
-  `rounded` value is `amount` rounded to the nearest dollar
-
-  Example:
-    {
-      "amount": "134758.44",
-      "state": "HI",
-      "rounded": 134758
-    }
-  assign the resulting new array to `datasetWithRoundedDollar`
-*/
-var datasetWithRoundedDollar = null;
-
-/*
-  DO NOT MUTATE DATA.
-
-  create a new dataset where each bank object is a new object.
-  `amount` and `state` values will be transferred to the new object.
-  This new object is different, you will add one new key of `roundedDime`
-
-  `roundedDime` value is `amount` rounded to the nearest 10th of a cent
-
-  Example 1
-    {
-      "amount": "134758.46",
-      "state": "HI"
-      "roundedDime": 134758.5
-    }
-  Example 2
-    {
-      "amount": "134758.44",
-      "state": "HI"
-      "roundedDime": 134758.4
-    }
-  assign the resulting new array to `roundedDime`
-*/
-var datasetWithRoundedDime = null;
-
 // set sumOfBankBalances to be the sum of all value held at `amount` for each bank object
 var sumOfBankBalances = null;
 
@@ -62,7 +18,7 @@ var sumOfBankBalances = null;
     Ohio
     Georgia
     Delaware
-  take each `amount` and add 18.9% interest to it rounded to the nearest cent
+  take each `amount` and add 18.9% interest to it rounded to the nearest dollar 
   and then sum it all up into one value saved to `sumOfInterests`
  */
 var sumOfInterests = null;
@@ -76,11 +32,11 @@ var sumOfInterests = null;
     the two letter state abbreviation
   and the value is:
     the sum of all amounts from that state
-    the value must be rounded to the nearest cent
+    the value must be rounded to the nearest dollar
 
   note: During your summation (
     if at any point durig your calculation where the number looks like `2486552.9779399997`
-    round this number to the nearest 10th of a cent before moving on.
+    round this number to the nearest dollar before moving on.
   )
  */
 var stateSums = null;
@@ -99,7 +55,7 @@ var stateSums = null;
 
   note: During your summation (
     if at any point durig your calculation where the number looks like `2486552.9779399997`
-    round this number to the nearest 10th of a cent before moving on.
+    round this number to the nearest dollar before moving on.
   )
  */
 var sumOfHighInterests = null;
@@ -153,8 +109,6 @@ var anyStatesInHigherStateSum = null;
 
 module.exports = {
   hundredThousandairs : hundredThousandairs,
-  datasetWithRoundedDollar : datasetWithRoundedDollar,
-  datasetWithRoundedDime : datasetWithRoundedDime,
   sumOfBankBalances : sumOfBankBalances,
   sumOfInterests : sumOfInterests,
   sumOfHighInterests : sumOfHighInterests,

--- a/dataset.json
+++ b/dataset.json
@@ -1,403 +1,403 @@
 {
   "bankBalances" : [
     {
-      "amount": "822370.71",
+      "amount": "822370",
       "state": "ME"
     },
     {
-      "amount": "968817.53",
+      "amount": "968817",
       "state": "WI"
     },
     {
-      "amount": "587603.26",
+      "amount": "587603",
       "state": "OH"
     },
     {
-      "amount": "657617.83",
+      "amount": "657617",
       "state": "FL"
     },
     {
-      "amount": "378192.36",
+      "amount": "378192",
       "state": "DE"
     },
     {
-      "amount": "669546.11",
+      "amount": "669546",
       "state": "AL"
     },
     {
-      "amount": "608626.44",
+      "amount": "608626",
       "state": "OK"
     },
     {
-      "amount": "231272.04",
+      "amount": "231272",
       "state": "UT"
     },
     {
-      "amount": "382748.79",
+      "amount": "382748",
       "state": "OH"
     },
     {
-      "amount": "683737.17",
+      "amount": "683737",
       "state": "AR"
     },
     {
-      "amount": "913216.09",
+      "amount": "913216",
       "state": "PA"
     },
     {
-      "amount": "729204.39",
+      "amount": "729204",
       "state": "IA"
     },
     {
-      "amount": "573816.42",
+      "amount": "573816",
       "state": "VT"
     },
     {
-      "amount": "315166.45",
+      "amount": "315166",
       "state": "GA"
     },
     {
-      "amount": "811418.42",
+      "amount": "811418",
       "state": "AR"
     },
     {
-      "amount": "381043.13",
+      "amount": "381043",
       "state": "WI"
     },
     {
-      "amount": "29610.00",
+      "amount": "29610",
       "state": "GA"
     },
     {
-      "amount": "726904.66",
+      "amount": "726904",
       "state": "TX"
     },
     {
-      "amount": "341364.05",
+      "amount": "341364",
       "state": "MI"
     },
     {
-      "amount": "435105.78",
+      "amount": "435105",
       "state": "IL"
     },
     {
-      "amount": "734090.27",
+      "amount": "734090",
       "state": "UT"
     },
     {
-      "amount": "609216.58",
+      "amount": "609216",
       "state": "VA"
     },
     {
-      "amount": "965891.90",
+      "amount": "965891",
       "state": "PA"
     },
     {
-      "amount": "207074.79",
+      "amount": "207074",
       "state": "MD"
     },
     {
-      "amount": "979009.78",
+      "amount": "979009",
       "state": "LA"
     },
     {
-      "amount": "648470.73",
+      "amount": "648470",
       "state": "WI"
     },
     {
-      "amount": "875720.82",
+      "amount": "875720",
       "state": "IN"
     },
     {
-      "amount": "481642.65",
+      "amount": "481642",
       "state": "CA"
     },
     {
-      "amount": "452227.67",
+      "amount": "452227",
       "state": "WA"
     },
     {
-      "amount": "126198.26",
+      "amount": "126198",
       "state": "VT"
     },
     {
-      "amount": "448019.33",
+      "amount": "448019",
       "state": "UT"
     },
     {
-      "amount": "759570.28",
+      "amount": "759570",
       "state": "WY"
     },
     {
-      "amount": "669394.12",
+      "amount": "669394",
       "state": "TN"
     },
     {
-      "amount": "934418.07",
+      "amount": "934418",
       "state": "VT"
     },
     {
-      "amount": "471073.38",
+      "amount": "471073",
       "state": "MA"
     },
     {
-      "amount": "461330.63",
+      "amount": "461330",
       "state": "MS"
     },
     {
-      "amount": "875684.36",
+      "amount": "875684",
       "state": "OH"
     },
     {
-      "amount": "889649.10",
+      "amount": "889649",
       "state": "ME"
     },
     {
-      "amount": "250918.19",
+      "amount": "250918",
       "state": "TN"
     },
     {
-      "amount": "894487.65",
+      "amount": "894487",
       "state": "FL"
     },
     {
-      "amount": "617075.68",
+      "amount": "617075",
       "state": "AL"
     },
     {
-      "amount": "503473.28",
+      "amount": "503473",
       "state": "VT"
     },
     {
-      "amount": "57880.44",
+      "amount": "57880",
       "state": "NE"
     },
     {
-      "amount": "293464.54",
+      "amount": "293464",
       "state": "MT"
     },
     {
-      "amount": "551208.99",
+      "amount": "551208",
       "state": "IL"
     },
     {
-      "amount": "438527.25",
+      "amount": "438527",
       "state": "AZ"
     },
     {
-      "amount": "442807.71",
+      "amount": "442807",
       "state": "WY"
     },
     {
-      "amount": "859671.51",
+      "amount": "859671",
       "state": "ME"
     },
     {
-      "amount": "692388.34",
+      "amount": "692388",
       "state": "WI"
     },
     {
-      "amount": "667475.55",
+      "amount": "667475",
       "state": "VT"
     },
     {
-      "amount": "325329.34",
+      "amount": "325329",
       "state": "MN"
     },
     {
-      "amount": "907797.58",
+      "amount": "907797",
       "state": "WY"
     },
     {
-      "amount": "737459.47",
+      "amount": "737459",
       "state": "DE"
     },
     {
-      "amount": "670397.57",
+      "amount": "670397",
       "state": "OK"
     },
     {
-      "amount": "516781.69",
+      "amount": "516781",
       "state": "NE"
     },
     {
-      "amount": "650197.88",
+      "amount": "650197",
       "state": "OH"
     },
     {
-      "amount": "765581.58",
+      "amount": "765581",
       "state": "MO"
     },
     {
-      "amount": "713141.52",
+      "amount": "713141",
       "state": "AL"
     },
     {
-      "amount": "44830.89",
+      "amount": "44830",
       "state": "LA"
     },
     {
-      "amount": "212126.39",
+      "amount": "212126",
       "state": "ME"
     },
     {
-      "amount": "7426.28",
+      "amount": "7426",
       "state": "PA"
     },
     {
-      "amount": "839409.01",
+      "amount": "839409",
       "state": "AL"
     },
     {
-      "amount": "115019.34",
+      "amount": "115019",
       "state": "MI"
     },
     {
-      "amount": "65030.07",
+      "amount": "65030",
       "state": "WA"
     },
     {
-      "amount": "618847.07",
+      "amount": "618847",
       "state": "IL"
     },
     {
-      "amount": "944609.01",
+      "amount": "944609",
       "state": "AZ"
     },
     {
-      "amount": "878072.21",
+      "amount": "878072",
       "state": "GA"
     },
     {
-      "amount": "706919.12",
+      "amount": "706919",
       "state": "AR"
     },
     {
-      "amount": "540560.47",
+      "amount": "540560",
       "state": "WY"
     },
     {
-      "amount": "246311.95",
+      "amount": "246311",
       "state": "MA"
     },
     {
-      "amount": "588847.38",
+      "amount": "588847",
       "state": "FL"
     },
     {
-      "amount": "261729.11",
+      "amount": "261729",
       "state": "KY"
     },
     {
-      "amount": "593282.64",
+      "amount": "593282",
       "state": "LA"
     },
     {
-      "amount": "816974.09",
+      "amount": "816974",
       "state": "WA"
     },
     {
-      "amount": "461729.71",
+      "amount": "461729",
       "state": "DE"
     },
     {
-      "amount": "344141.38",
+      "amount": "344141",
       "state": "CT"
     },
     {
-      "amount": "355164.16",
+      "amount": "355164",
       "state": "KS"
     },
     {
-      "amount": "975500.37",
+      "amount": "975500",
       "state": "KS"
     },
     {
-      "amount": "173539.83",
+      "amount": "173539",
       "state": "AK"
     },
     {
-      "amount": "566473.23",
+      "amount": "566473",
       "state": "MA"
     },
     {
-      "amount": "905763.57",
+      "amount": "905763",
       "state": "TN"
     },
     {
-      "amount": "676161.17",
+      "amount": "676161",
       "state": "MN"
     },
     {
-      "amount": "901770.40",
+      "amount": "901770",
       "state": "HI"
     },
     {
-      "amount": "60734.29",
+      "amount": "60734",
       "state": "UT"
     },
     {
-      "amount": "645333.35",
+      "amount": "645333",
       "state": "IL"
     },
     {
-      "amount": "267949.46",
+      "amount": "267949",
       "state": "WI"
     },
     {
-      "amount": "291868.97",
+      "amount": "291868",
       "state": "CA"
     },
     {
-      "amount": "258525.05",
+      "amount": "258525",
       "state": "ID"
     },
     {
-      "amount": "670378.49",
+      "amount": "670378",
       "state": "AK"
     },
     {
-      "amount": "563501.70",
+      "amount": "563501",
       "state": "FL"
     },
     {
-      "amount": "95546.27",
+      "amount": "95546",
       "state": "IL"
     },
     {
-      "amount": "716276.28",
+      "amount": "716276",
       "state": "CT"
     },
     {
-      "amount": "882101.62",
+      "amount": "882101",
       "state": "NE"
     },
     {
-      "amount": "842577.56",
+      "amount": "842577",
       "state": "VA"
     },
     {
-      "amount": "374506.19",
+      "amount": "374506",
       "state": "MD"
     },
     {
-      "amount": "483084.94",
+      "amount": "483084",
       "state": "NE"
     },
     {
-      "amount": "910596.45",
+      "amount": "910596",
       "state": "IA"
     },
     {
-      "amount": "808045.11",
+      "amount": "808045",
       "state": "TX"
     },
     {
-      "amount": "203122.41",
+      "amount": "203122",
       "state": "ID"
     },
     {
-      "amount": "196085.92",
+      "amount": "196085",
       "state": "MS"
     }
   ]

--- a/test/array-methods-spec.js
+++ b/test/array-methods-spec.js
@@ -11,47 +11,15 @@ describe('Array Methods', function() {
     });
   });
 
-  describe('datasetWithRoundedDollar', function() {
-    it('should be an array of accounts with an added key `rounded`', function() {
-      arrayMethods.datasetWithRoundedDollar.should.have.length(100);
-      arrayMethods.datasetWithRoundedDollar.every(function (account){ return account.hasOwnProperty('rounded'); }).should.be.true;
-    });
-
-    it('each accounts `rounded` value should be rounded to the nearest dollar', function() {
-      arrayMethods.datasetWithRoundedDollar[0].rounded.should.be.equal(822371);
-      arrayMethods.datasetWithRoundedDollar[7].rounded.should.be.equal(231272);
-      arrayMethods.datasetWithRoundedDollar[9].rounded.should.be.equal(683737);
-      arrayMethods.datasetWithRoundedDollar[10].rounded.should.be.equal(913216);
-      arrayMethods.datasetWithRoundedDollar[99].rounded.should.be.equal(196086);
-    });
-  });
-
-  describe('datasetWithRoundedDime', function() {
-    it('should be a new dataset of accounts with an added key `roundedDime`', function() {
-      arrayMethods.datasetWithRoundedDime.should.have.length(100);
-      arrayMethods.datasetWithRoundedDime.every(function (account){ return account.hasOwnProperty('amount'); }).should.be.true;
-      arrayMethods.datasetWithRoundedDime.every(function (account){ return account.hasOwnProperty('roundedDime'); }).should.be.true;
-
-      // should NOT have a property of `rounded`
-      arrayMethods.datasetWithRoundedDime.every(function (account){ return !account.hasOwnProperty('rounded'); }).should.be.true;
-    });
-
-    it('each account\'s `roundedDime` value should be the `amount` value rounded to the nearest dime', function() {
-      arrayMethods.datasetWithRoundedDime[0].roundedDime.should.be.equal(822370.7);
-      arrayMethods.datasetWithRoundedDime[7].roundedDime.should.be.equal(231272);
-      arrayMethods.datasetWithRoundedDime[99].roundedDime.should.be.equal(196085.9);
-    });
-  });
-
   describe('sumOfBankBalances', function() {
-    it('should be the sum of all amounts in bankBalances, rounded to the nearest cent', function() {
-      arrayMethods.sumOfBankBalances.should.be.equal(55502603.02);
+    it('should be the sum of all amounts in bankBalances, rounded to the nearest dollar', function() {
+      arrayMethods.sumOfBankBalances.should.be.equal(55502559);
     });
   });
 
   describe('sumOfInterests', function() {
-    it('should be the sum the 18.9% interest for all amounts in bankBalances, in the selected states, rounded to the nearest cent', function() {
-      arrayMethods.sumOfInterests.should.be.equal(2504611.23);
+    it('should be the sum the 18.9% interest for all amounts in bankBalances, in the selected states, rounded to the nearest dollar', function() {
+      arrayMethods.sumOfInterests.should.be.equal(2504608);
     });
   });
 
@@ -66,17 +34,17 @@ describe('Array Methods', function() {
       stateKeys.should.include.members(['ME', 'WI', 'ID', 'HI']);
     });
 
-    it('should have a keys with values being the sum for each state, rounded to the nearest cent', function() {
-      arrayMethods.stateSums.ME.should.be.equal(2783817.71);
-      arrayMethods.stateSums.WI.should.be.equal(2958669.19);
-      arrayMethods.stateSums.ID.should.be.equal(461647.46);
-      arrayMethods.stateSums.HI.should.be.equal(901770.4);
+    it('should have a keys with values being the sum for each state, rounded to the nearest dollar', function() {
+      arrayMethods.stateSums.ME.should.be.equal(2783816);
+      arrayMethods.stateSums.WI.should.be.equal(2958667);
+      arrayMethods.stateSums.ID.should.be.equal(461647);
+      arrayMethods.stateSums.HI.should.be.equal(901770);
     });
   });
 
   describe('sumOfHighInterests', function() {
-    it('should be the sum the 18.9% interest for all amounts in bankBalances, where the amount of the sum of interests in that state is greater than 50,000, in the selected states, rounded to the nearest cent', function() {
-      arrayMethods.sumOfHighInterests.should.be.equal(7935913.99);
+    it('should be the sum the 18.9% interest for all amounts in bankBalances, where the amount of the sum of interests in that state is greater than 50,000, in the selected states, rounded to the nearest dollar', function() {
+      arrayMethods.sumOfHighInterests.should.be.equal(7985374);
     });
   });
 
@@ -92,7 +60,7 @@ describe('Array Methods', function() {
 
   describe('higherStateSums', function() {
     it('should be the sum of all amounts of every state, where the sum of amounts in the state is greater than 1,000,000', function() {
-      arrayMethods.higherStateSums.should.be.equal(48629878.25);
+      arrayMethods.higherStateSums.should.be.equal(48629843);
     });
   });
 


### PR DESCRIPTION
Removed the requirement to round to cents from all exercises.

Updated the dataset to only contain dollar amounts.

Updated tests to match exercises.